### PR TITLE
Add cors to allow front end to talk

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,9 @@ gem 'figaro'
 gem 'faraday'
 gem 'recombee_api_client'
 gem 'activerecord-import'
+gem 'rack-cors', :require => 'rack/cors'
+# gem 'simplecov'
+
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,7 @@ GEM
     rack (2.0.3)
     rack-cache (1.7.1)
       rack (>= 0.4)
+    rack-cors (1.0.2)
     rack-test (0.8.2)
       rack (>= 1.0, < 3)
     rails (5.1.4)
@@ -242,6 +243,7 @@ DEPENDENCIES
   pg (~> 0.18)
   pry-rails
   puma (~> 3.7)
+  rack-cors
   rails (~> 5.1.4)
   recombee_api_client
   redis (~> 3.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,11 @@ module Recombee
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+    config.action_dispatch.default_headers = {
+      'Access-Control-Allow-Origin': 'http://localhost:3001, https://localhost:3001',
+      'Access-Control-Request-Method': %w{GET POST PUT PATCH DELETE UPDATE OPTIONS}.join(","),
+      'Content-Type': 'application/json',
+      'Accept': 'application/json'
+    }
   end
 end


### PR DESCRIPTION
Add `gem rack-cors` to allow for cross origin resource sharing.
Add 
```
#config/application.rb
    config.action_dispatch.default_headers = {
      'Access-Control-Allow-Origin': 'http://localhost:3001, https://localhost:3001',
      'Access-Control-Request-Method': %w{GET POST PUT PATCH DELETE UPDATE OPTIONS}.join(","),
      'Content-Type': 'application/json',
      'Accept': 'application/json'
    }
```
to `application.rb`

Add 
```
# config/initializers/cors.rb
Rails.application.config.middleware.insert_before 0, Rack::Cors do
  allow do
    origins '*'

    resource '*',
      headers: :any,
      methods: [:get, :options, :head]
  end
end
``` 